### PR TITLE
✨ ResetEmulator(projectID string) that auto detects emulator host

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -27,8 +27,7 @@ jobs:
           sleep 10
       - name: Run test
         env:
-          EMULATOR_HOST: localhost
-          EMULATOR_PORT: 8030
+          FIRESTORE_EMULATOR_HOST: localhost:8030
         run: |
           go test ./... -coverprofile=coverage.txt
       - name: Upload coverage reports to Codecov

--- a/reset_emulator.go
+++ b/reset_emulator.go
@@ -1,0 +1,38 @@
+package emutils
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+)
+
+const regexHost = `[^:]+:\d{1,5}`
+
+func ResetEmulator(projectID string) error {
+	emuHost := os.Getenv("FIRESTORE_EMULATOR_HOST")
+	if emuHost == "" {
+		return fmt.Errorf("missing FIRESTORE_EMULATOR_HOST")
+	}
+	re := regexp.MustCompile(regexHost)
+	if !re.MatchString(emuHost) {
+		return fmt.Errorf("invalid FIRESTORE_EMULATOR_HOST, should be host:port but got: %s", emuHost)
+	}
+
+	url := fmt.Sprintf(
+		"http://%s/emulator/v1/projects/%s/databases/(default)/documents",
+		emuHost, projectID,
+	)
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/reset_emulator.go
+++ b/reset_emulator.go
@@ -7,18 +7,45 @@ import (
 	"regexp"
 )
 
-const regexHost = `[^:]+:\d{1,5}`
+var regexHost, regexProjID regexp.Regexp
+
+func init() {
+	regexHost = *regexp.MustCompile(`^[^:]+:\d{1,5}$`)
+	regexProjID = *regexp.MustCompile(`^[a-z][a-z0-9-]{4,28}[a-z0-9]$`)
+}
 
 func ResetEmulator(projectID string) error {
-	emuHost := os.Getenv("FIRESTORE_EMULATOR_HOST")
-	if emuHost == "" {
-		return fmt.Errorf("missing FIRESTORE_EMULATOR_HOST")
+	if !regexProjID.MatchString(projectID) {
+		return fmt.Errorf("project ID must match %s, %s", regexProjID.String(), projectID)
 	}
-	re := regexp.MustCompile(regexHost)
-	if !re.MatchString(emuHost) {
-		return fmt.Errorf("invalid FIRESTORE_EMULATOR_HOST, should be host:port but got: %s", emuHost)
+	emuHost, err := loadEmulatorHostEnv()
+	if err != nil {
+		return err
 	}
+	return execResetReq(emuHost, projectID)
+}
 
+func loadEmulatorHostEnv() (host string, err error) {
+	emuHost := os.Getenv("FIRESTORE_EMULATOR_HOST")
+	emuPort := os.Getenv("FIRESTORE_EMULATOR_PORT")
+	if emuHost == "" {
+		if emuPort == "" {
+			// if all variables are not set, throw error
+			return "", fmt.Errorf("missing FIRESTORE_EMULATOR_HOST")
+		}
+		return fmt.Sprintf("localhost:%s", emuPort), nil
+	}
+	// validate if Host is in the format of host:port
+	if regexHost.MatchString(emuHost) {
+		return emuHost, nil
+	}
+	if emuPort == "" {
+		return "", fmt.Errorf("invalid FIRESTORE_EMULATOR_HOST, should be host:port but got: %s", emuHost)
+	}
+	return fmt.Sprintf("%s:%s", emuHost, emuPort), nil
+}
+
+func execResetReq(emuHost, projectID string) error {
 	url := fmt.Sprintf(
 		"http://%s/emulator/v1/projects/%s/databases/(default)/documents",
 		emuHost, projectID,
@@ -31,6 +58,7 @@ func ResetEmulator(projectID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to send request: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}

--- a/reset_emulator_test.go
+++ b/reset_emulator_test.go
@@ -1,0 +1,139 @@
+package emutils_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/firestore"
+	emutils "github.com/Shion1305/firestore_emutils"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestResetEmulatorIntegration(t *testing.T) {
+	defaultValue := os.Getenv("FIRESTORE_EMULATOR_HOST")
+	if defaultValue == "" {
+		t.Skip("FIRESTORE_EMULATOR_HOST not set; skipping integration test.")
+	}
+	tests := []struct {
+		name      string
+		projectID string
+		setup     func(t *testing.T)
+		wantErr   bool
+	}{
+		{
+			name:      "Missing FIRESTORE_EMULATOR_HOST",
+			projectID: "dummy-project",
+			setup: func(t *testing.T) {
+				_ = os.Unsetenv("FIRESTORE_EMULATOR_HOST")
+			},
+			wantErr: true,
+		},
+		{
+			name:      "Valid Reset with FIRESTORE_EMULATOR_HOST",
+			projectID: "test-project",
+			setup: func(t *testing.T) {
+				_ = os.Setenv("FIRESTORE_EMULATOR_HOST", defaultValue)
+			},
+			wantErr: false,
+		},
+		{
+			name:      "Valid Reset with FIRESTORE_EMULATOR_PORT",
+			projectID: "test-project",
+			setup: func(t *testing.T) {
+				_ = os.Unsetenv("FIRESTORE_EMULATOR_HOST")
+				splits := strings.Split(defaultValue, ":")
+				p := splits[len(splits)-1]
+				_ = os.Setenv("FIRESTORE_EMULATOR_PORT", p)
+			},
+			wantErr: false,
+		},
+		{
+			name:      "Empty project ID",
+			projectID: "",
+			setup: func(t *testing.T) {
+				_ = os.Setenv("FIRESTORE_EMULATOR_HOST", defaultValue)
+			},
+			wantErr: true,
+		},
+		{
+			name:      "Invalid project ID",
+			projectID: "invalidID",
+			setup: func(t *testing.T) {
+				_ = os.Setenv("FIRESTORE_EMULATOR_HOST", defaultValue)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc // capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup(t)
+
+			err := emutils.ResetEmulator(tc.projectID)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected an error, but got none")
+			} else if !tc.wantErr && err != nil {
+				t.Errorf("did not expect an error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestResetEmulator_AddDocsThenReset(t *testing.T) {
+	// Skip if the emulator host is not configured
+	if os.Getenv("FIRESTORE_EMULATOR_HOST") == "" {
+		t.Skip("FIRESTORE_EMULATOR_HOST is not set, skipping integration test.")
+	}
+
+	ctx := context.Background()
+	const (
+		projectID  = "test-project"
+		collection = "test-collection"
+		document   = "testDoc"
+	)
+
+	// Create a Firestore client without authentication.
+	// This client will connect to the local emulator.
+	client, err := firestore.NewClient(ctx, projectID, option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("failed to create Firestore client: %v", err)
+	}
+	defer client.Close()
+
+	// Insert a document
+	_, err = client.Collection(collection).Doc(document).Set(ctx, map[string]interface{}{
+		"hello": "world",
+	})
+	if err != nil {
+		t.Fatalf("failed to add document: %v", err)
+	}
+
+	// Verify the document exists
+	snapshot, err := client.Collection(collection).Doc(document).Get(ctx)
+	if err != nil {
+		t.Fatalf("failed to retrieve document: %v", err)
+	}
+	if val, ok := snapshot.Data()["hello"]; !ok || val != "world" {
+		t.Fatalf("expected 'hello=world' in document, got: %v", snapshot.Data())
+	}
+
+	// Call ResetEmulator to clear data
+	if err := emutils.ResetEmulator(projectID); err != nil {
+		t.Fatalf("ResetEmulator returned an error: %v", err)
+	}
+
+	// Verify the document is no longer found
+	_, err = client.Collection(collection).Doc(document).Get(ctx)
+	if err == nil {
+		t.Fatalf("expected a 'not found' error, but got none")
+	}
+	// Check for the Firestore NotFound status
+	if s, ok := status.FromError(err); !ok || s.Code() != codes.NotFound {
+		t.Fatalf("expected a NotFound error, got: %v", err)
+	}
+}


### PR DESCRIPTION
# Overview
## New Features
- `ResetEmulator` : automatically detects the Firestore emulator host from an environment variable and sends an HTTP DELETE request to reset the emulator state.